### PR TITLE
Paramedir: Make "some events missing" not be fatal

### DIFF
--- a/api/kernelconnection.h
+++ b/api/kernelconnection.h
@@ -57,18 +57,18 @@ typedef std::pair< TEventType, TEventValue > TTypeValuePair;
 enum UserMessageID
 {
   MessageCFGNoneEvents = 0,
-  MessageCFGSomeEvents,
   MessageCFGZeroObjects,
   MessageCFGMultipleValues,
+  MessageCFGSomeEvents,
   UserMessageSize
 };
 
 static const std::string userMessages[ UserMessageSize ] =
 {
   "None of the events specified in the filter appear in the trace.",
-  "Some of the events specified in the filter doesn't appear in the trace.",
   "Some timeline has 0 objects selected at some level.",
-  "Some of the events specified in the filter have multiple instances. All of them will be included."
+  "Some of the events specified in the filter have multiple instances. All of them will be included.",
+  "Some of the events specified in the filter doesn't appear in the trace."
 };
 
 class KernelConnection


### PR DESCRIPTION
fix for #5 
Simplest approach is to move things in the UserMessage enums so that some events missing, ceases to be a Fatal error.
