### PR TITLE
Missing namespace identifier

### DIFF
--- a/api/window.h
+++ b/api/window.h
@@ -1298,7 +1298,7 @@ class WindowProxy: public Window
   private:
     Window *myWindow;
 #ifdef PARALLEL_ENABLED
-    vector<Window *> parallelClone;
+    std::vector<Window *> parallelClone;
 #endif // PARALLEL_ENABLED
 
     Trace *myTrace;


### PR DESCRIPTION
Build fails without this change, with gcc `10.1.0`.