### PR TITLE
Add the PCF option DONT_EXPAND_COLORS

### DIFF
--- a/api/semanticcolor.cpp
+++ b/api/semanticcolor.cpp
@@ -232,8 +232,9 @@ rgb CodeColor::getColor( PRV_UINT32 pos ) const
 {
   if( pos == 0 && ParaverConfig::getInstance()->getColorsTimelineUseZero() )
     return ParaverConfig::getInstance()->getColorsTimelineColorZero();
-  pos = pos % colors.size();
-  return colors[ pos ];
+  // Skip the black at 0
+  pos = pos % (colors.size() - 1);
+  return colors[ pos + 1 ];
 }
 
 void CodeColor::setColor( PRV_UINT32 whichPos, rgb whichColor )
@@ -248,6 +249,12 @@ void CodeColor::setColor( PRV_UINT32 whichPos, rgb whichColor )
     }
   }
   colors[ whichPos ] = whichColor;
+}
+
+void CodeColor::cutAfter( PRV_UINT32 pos )
+{
+  if ( pos < colors.size() )
+    colors.erase( colors.begin() + pos, colors.end() );
 }
 
 void CodeColor::setCustomColor( TSemanticValue whichValue, rgb color ) 

--- a/api/semanticcolor.h
+++ b/api/semanticcolor.h
@@ -98,6 +98,7 @@ class CodeColor: public SemanticColor
 
     PRV_UINT32 getNumColors() const;
     void setColor( PRV_UINT32 pos, rgb color );
+    void cutAfter( PRV_UINT32 pos );
     void setCustomColor( TSemanticValue whichValue, rgb color );
     bool existCustomColors() const;
     const std::map<TSemanticValue, rgb>& getCustomPalette() const;

--- a/api/trace.cpp
+++ b/api/trace.cpp
@@ -461,11 +461,20 @@ void TraceProxy::parsePCF( const string& whichFile )
 
   rgb tmpColor;
   const std::map< uint32_t, PCFFileParser<>::rgb >& semanticColors = pcfParser.getSemanticColors();
+  uint32_t maxValue = 0;
+
   for ( auto it : semanticColors )
   {
     std::tie( tmpColor.red, tmpColor.green, tmpColor.blue ) = it.second;
     myCodeColor.setColor( it.first, tmpColor );
+    if (it.first > maxValue)
+      maxValue = it.first;
   }
+
+  // Cut the palette after the highest defined value, so there are no
+  // extra expanded values
+  if ( !pcfParser.expandColors )
+    myCodeColor.cutAfter(maxValue);
 
   myEventLabels = EventLabels( pcfParser );
   myStateLabels = StateLabels( pcfParser );

--- a/utils/traceparser/pcffileparser.cpp
+++ b/utils/traceparser/pcffileparser.cpp
@@ -286,6 +286,7 @@ constexpr char PCF_LABEL_SPEED[]               = "SPEED";
 constexpr char PCF_LABEL_FLAG_ICONS[]          = "FLAG_ICONS";
 constexpr char PCF_LABEL_NUM_OF_STATE_COLORS[] = "NUM_OF_STATE_COLORS";
 constexpr char PCF_LABEL_YMAX_SCALE[]          = "YMAX_SCALE";
+constexpr char PCF_LABEL_DONT_EXPAND_COLORS[]  = "DONT_EXPAND_COLORS";
 
 template< typename dummyParser = std::nullptr_t >
 class DefaultOptionsParser : public PCFFileParser<>::SectionParser<>
@@ -293,12 +294,13 @@ class DefaultOptionsParser : public PCFFileParser<>::SectionParser<>
   public:
     DefaultOptionsParser( PCFFileParser<> *whichMainParser ) : PCFFileParser<>::SectionParser<>( whichMainParser ) 
     {
-      parameterSetter[ PCF_LABEL_LEVEL ]      = [this]( std::string line ) { mainParser->level = line; };
-      parameterSetter[ PCF_LABEL_UNITS ]      = [this]( std::string line ) { mainParser->units = line; };
-      parameterSetter[ PCF_LABEL_LOOK_BACK ]  = [this]( std::string line ) { mainParser->lookBack = line; };
-      parameterSetter[ PCF_LABEL_SPEED ]      = [this]( std::string line ) { mainParser->speed = line; };
-      parameterSetter[ PCF_LABEL_FLAG_ICONS ] = [this]( std::string line ) { mainParser->flagIcons = line; };
-      parameterSetter[ PCF_LABEL_YMAX_SCALE ] = [this]( std::string line ) { mainParser->ymaxScale = line; };
+      parameterSetter[ PCF_LABEL_LEVEL ]              = [this]( std::string line ) { mainParser->level = line; };
+      parameterSetter[ PCF_LABEL_UNITS ]              = [this]( std::string line ) { mainParser->units = line; };
+      parameterSetter[ PCF_LABEL_LOOK_BACK ]          = [this]( std::string line ) { mainParser->lookBack = line; };
+      parameterSetter[ PCF_LABEL_SPEED ]              = [this]( std::string line ) { mainParser->speed = line; };
+      parameterSetter[ PCF_LABEL_FLAG_ICONS ]         = [this]( std::string line ) { mainParser->flagIcons = line; };
+      parameterSetter[ PCF_LABEL_YMAX_SCALE ]         = [this]( std::string line ) { mainParser->ymaxScale = line; };
+      parameterSetter[ PCF_LABEL_DONT_EXPAND_COLORS ] = [this]( std::string line ) { mainParser->expandColors = false; };
     }
 
     virtual ~DefaultOptionsParser() = default;

--- a/utils/traceparser/pcffileparser.h
+++ b/utils/traceparser/pcffileparser.h
@@ -100,6 +100,7 @@ class PCFFileParser
     void setEventLabel( TEventType eventType, const std::string& label );
     void setEventValues( TEventType eventType, const std::map< TEventValue, std::string >& values );
     void setEventValueLabel( TEventType eventType, TEventValue eventValue, const std::string& label );
+    bool expandColors = true;
 
   private:
     struct EventTypeData


### PR DESCRIPTION
Allows the user to specify the complete palette in the PCF, preventing Paraver from expanding the colors.

Fixes https://github.com/bsc-performance-tools/wxparaver/issues/8

Here is an example PCF with a carefully selected palette that contains no dark colors:

```
DEFAULT_OPTIONS

LEVEL               THREAD
UNITS               NANOSEC
LOOK_BACK           100
SPEED               1
FLAG_ICONS          ENABLED
NUM_OF_STATE_COLORS 1000
YMAX_SCALE          37
DONT_EXPAND_COLORS  1


DEFAULT_SEMANTIC

THREAD_FUNC         State As Is


STATES_COLOR
0   {  0,   0,   0}
1   {229,   0,   0}
2   {183,   0,   0}
3   {229, 106,   0}
4   {193,  89,   0}
5   {235, 174,   0}
6   {202, 151,   0}
7   {235, 235,   0}
8   {196, 197,   0}
9   {152, 235,   0}
10  {125, 192,   0}
11  { 19, 235,   0}
12  { 15, 181,   0}
13  {  0, 235, 234}
14  {  0, 199, 198}
15  {  0, 178, 235}
16  {  0, 152, 200}
17  { 70, 119, 235}
18  { 53,  96, 199}
19  { 70,  73, 235}
20  { 90,   0, 234}
21  { 84,   0, 219}
22  {168,   0, 234}
23  {234,   0, 230}


EVENT_TYPE
0 36         Label
VALUES
1133833770 VeryDark
9770 MaybeDark
31999 31999
32000 32000
32001 32001
```

And here you can see the comparison when loading a test trace (with increasing values 0, 1, 2, etc.) without and with the new option `DONT_EXPAND_COLORS  1`, respectively.

![timeline-palette](https://user-images.githubusercontent.com/3866127/222454247-33af0aa9-9c55-457e-8dae-9c83ffd8abf0.png)

You can see that only the colors defined in the PCF appear in the trace.